### PR TITLE
add: configure login btn txt, rm password option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ import LoginScreen, { SocialButton } from "react-native-login-screen";
 | disableSignup           |  boolean   |        false        | disable the signup if you do not want to use it     |
 | disableDivider          |  boolean   |        false        | disable the divider if you do not want to use it    |
 | disableSocialButtons    |  boolean   |        false        | disable the all social buttons                      |
+| disablePasswordInput    |  boolean   |        false        | disable the password text input                     |
 | emailPlaceholder        |   string   |       "Email"       | change email placeholder text                       |
-| passwordPlaceholder     |   string   |     "Password"      | change password placeholder text                    |
+| passwordPlaceholder     |   string   |      "Password"     | change password placeholder text                    |
+| loginButtonText         |   string   |       "Login"       | change login button's text                          |
 | style                   | ViewStyle  |       default       | set/override the default style for the container    |
 | dividerStyle            | ViewStyle  |       default       | set/override the default divider style              |
 | logoImageStyle          | ImageStyle |       default       | set/override the default image style                |

--- a/lib/LoginScreen.tsx
+++ b/lib/LoginScreen.tsx
@@ -33,6 +33,8 @@ export interface ILoginScreenProps {
   emailPlaceholder?: string;
   passwordPlaceholer?: string;
   disableSignup?: boolean;
+  disablePasswordInput?: boolean;
+  loginButtonText?: string;
   style?: CustomStyleProp;
   dividerStyle?: CustomStyleProp;
   logoImageStyle?: CustomImageStyleProp;
@@ -66,6 +68,8 @@ const LoginScreen: React.FC<ILoginScreenProps> = ({
   logoImageSource,
   onLoginPress,
   disableSocialButtons,
+  disablePasswordInput,
+  loginButtonText = "Login",
   onSignupPress,
   onEmailChange,
   onPasswordChange,
@@ -89,13 +93,15 @@ const LoginScreen: React.FC<ILoginScreenProps> = ({
   const TextInputContainer = () => (
     <View style={[styles.textInputContainer, textInputContainerStyle]}>
       <TextInput placeholder={emailPlaceholder} onChangeText={onEmailChange} />
-      <View style={styles.passwordTextInputContainer}>
-        <TextInput
-          placeholder={passwordPlaceholer}
-          secureTextEntry
-          onChangeText={onPasswordChange}
-        />
-      </View>
+      {disablePasswordInput && (
+        <View style={styles.passwordTextInputContainer}>
+          <TextInput
+            placeholder={passwordPlaceholer}
+            secureTextEntry
+            onChangeText={onPasswordChange}
+          />
+        </View>
+      )}
     </View>
   );
 
@@ -104,7 +110,9 @@ const LoginScreen: React.FC<ILoginScreenProps> = ({
       style={[styles.loginButtonStyle, loginButtonStyle]}
       onPress={onLoginPress}
     >
-      <Text style={[styles.loginTextStyle, loginTextStyle]}>Login</Text>
+      <Text style={[styles.loginTextStyle, loginTextStyle]}>
+        {loginButtonText}
+      </Text>
     </TouchableOpacity>
   );
 


### PR DESCRIPTION
I've added 2 bits:
1. Ability to remove password box for passwordless sign in.
2. Ability to access Login Button text.

Note:
I was unable to test this locally to test. I was following this [guide](https://medium.com/@alielmajdaoui/linking-local-packages-in-react-native-the-right-way-2ac6587dcfa2), but hit a few issues. In the future, could you add:
1. A piece of the README.md showing how to test locally.
2. a CONTRIBUTING.md

For now, I would love if we can get this change pushed as soon as you have time. Thanks for the lib!