### PR TITLE
Pass password and email to their TextInputs' value prop

### DIFF
--- a/lib/LoginScreen.tsx
+++ b/lib/LoginScreen.tsx
@@ -211,6 +211,7 @@ const LoginScreen: React.FC<ILoginScreenProps> = ({
               placeholder={emailPlaceholder}
               onChangeText={handleEmailChange}
               autoCapitalize="none"
+              value={email}
               {...emailTextInputProps}
             />
           </Tooltip>
@@ -252,6 +253,7 @@ const LoginScreen: React.FC<ILoginScreenProps> = ({
                   iconImageSource={eyeIcon}
                   autoCapitalize="none"
                   onIconPress={handleEyePress}
+                  value={password}
                   {...passwordTextInputProps}
                 />
               </Tooltip>


### PR DESCRIPTION
This should prevent https://github.com/WrathChaos/react-native-login-screen/issues/129 from happening.

Once TextInput accepts onChangeText prop, it becomes a controlled component, and looks for a value. If a value is not sent, then the input will keep clearing itself.

I suggest sending the value as we are already keeping it, and the user will not have to worry about sending it. But they still can, through textInputProps.