### PR TITLE
fix: packaging hygiene — missing peers, types/exports map, files whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-login-screen",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Fully Customizable & Ready to use Login Screen for React Native",
   "keywords": [
     "login",
@@ -58,5 +58,22 @@
     "copy:package": "cpx '../package.json' '../build/dist/'",
     "husky:lint": "npx husky add .husky/pre-commit 'npm run lint'",
     "husky:prettier": "npx husky set .husky/pre-commit 'npm run prettier'"
-  }
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0",
+    "react-native": ">=0.64.0"
+  },
+  "types": "./build/dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/dist/index.d.ts",
+      "default": "./build/dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "build",
+    "!build/dist/package.json",
+    "!build/dist/tsconfig.tsbuildinfo"
+  ]
 }


### PR DESCRIPTION
Wrongs in the published 5.0.0 tarball: `.idea/` (!), `.husky/`, `.github/`, dotfiles, TypeScript sources and tsbuildinfo shipped; no react / react-native peers; no `types` / `exports`.

Fixes (package.json only):
- Added `react >=17.0.0` / `react-native >=0.64.0` peers.
- `types` + `exports` map matching the published layout (`./build/dist/index.d.ts` first, `./package.json` export included).
- `files` whitelist restricted to `build/` — the social-button local-assets ship inside `build/dist/local-assets`, so runtime `require()`s keep working.
- `react-native-text-input-interactive` is genuinely imported and stays in `dependencies`.

No source changes. Publish as 5.0.1 after the npm account migration.